### PR TITLE
Fix compatibility with Faceball 2000 DX

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -462,18 +462,12 @@ bool retro_load_game(const struct retro_game_info* info)
        {
            mode = MODE_SINGLE_GAME_DUAL;
 
-          if (!strcmp(cart_name, "FACEBALL 2000   "))
+          if (!strncmp(cart_name, "FACEBALL 2000", 13))
            {
                delete master_link;
                master_link = NULL;
                linked_target_device = new faceball2000_cable(v_gb);
                v_gb[0]->set_linked_target(linked_target_device);
-
-               //set gb_type to GBC
-               for (int i = 0; i < emulated_gbs; i++)
-               {
-                   v_gb[0]->get_rom()->get_info()->gb_type = 2;
-               }
                break;
            }
           if (!strcmp(cart_name, "KWIRK"))


### PR DESCRIPTION
Faceball 2000 DX changes the ROM header title, so this change ensures only the common part of the title is checked.
Also, the "set GB type to GBC" thing was broken (it was only setting the first system, and setting it to SGB not GBC, and it wouldn't even do anything without adding the doublespeed trigger to the ROM itself) so I went and removed it since it was screwing up the colors in DX.