### PR TITLE
Remove outdated Wii U compiler flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,8 @@ else ifeq ($(platform), wiiu)
 	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 	CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-	CFLAGS += -DGEKKO -DHW_RVL -DWIIU -mwup -mcpu=750 -meabi -mhard-float -D__ppc__ -DMSB_FIRST -I$(DEVKITPRO)/libogc/include
+	CFLAGS += -DGEKKO -DHW_RVL -DWIIU -D__wiiu__ -DHW_WUP -ffunction-sections -fdata-sections
+	CFLAGS += -mcpu=750 -meabi -mhard-float -D__ppc__ -DMSB_FIRST -I$(DEVKITPRO)/libogc/include
 	CFLAGS += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
 	STATIC_LINKING = 1
 


### PR DESCRIPTION
libretro/RetroArch#14925 is going to update the Wii U version of RetroArch to build with the modern homebrew toolchain rather than the several-years-old version it builds with currently. In the time since the toolchain was last updated, the `-mwup` machine flag was dropped. This flag is synonymous with `-D__wiiu__ -DHW_WUP -ffunction-sections -fdata-sections`, all of which are supported on both the old and new toolchains.

This is safe to merge right now. Since the new flags are exactly equivalent, there's no change when building for the legacy toolchain. This change will simply mean doublecherryGB *continues* to compile once the toolchain update goes through.

While we're on the subject, though: the Wii U is a big-endian platform, and like TGBDual before it, doublecherryGB is currently non-functional on big-endian platforms; see libretro/tgbdual-libretro#3. Regretfully, this PR does not change that. It is purely a future-proofing buildfix.